### PR TITLE
Minor Fixes

### DIFF
--- a/src/data/items/charms.heroic.json
+++ b/src/data/items/charms.heroic.json
@@ -324,7 +324,7 @@
       "all_resistances": [10, 20]
     },
     "uniqueEffects": ["All Skills Class"],
-    "width": 2,
+    "width": 1,
     "height": 2
   }
 ]

--- a/src/data/skills/pyromancer.json
+++ b/src/data/skills/pyromancer.json
@@ -260,7 +260,7 @@
     "tree": "Arsonist",
     "position": {
       "row": 1,
-      "col": 1
+      "col": 0
     }
   },
   {
@@ -282,7 +282,7 @@
     "tree": "Arsonist",
     "position": {
       "row": 1,
-      "col": 2
+      "col": 1
     }
   },
   {
@@ -304,7 +304,7 @@
     "tree": "Arsonist",
     "position": {
       "row": 2,
-      "col": 1
+      "col": 0
     }
   },
   {


### PR DESCRIPTION
Contains two minor fixes:

1. Fixes the Charm width of Torch of Shadow
2. Fixes placement of three Pyromancer Skills to match in-game position