### PR TITLE
fix: Redneck passives and skills

### DIFF
--- a/src/data/skills/redneck.json
+++ b/src/data/skills/redneck.json
@@ -84,7 +84,7 @@
     "tree": "Hillbilly",
     "position": {
       "row": 0,
-      "col": 1
+      "col": 2
     },
     "damageType": "fire",
     "damageFormula": {
@@ -148,7 +148,7 @@
     "tree": "Hillbilly",
     "position": {
       "row": 1,
-      "col": 0
+      "col": 2
     },
     "damageType": "fire",
     "damageFormula": {
@@ -210,7 +210,7 @@
     "tree": "Hillbilly",
     "position": {
       "row": 1,
-      "col": 1
+      "col": 0
     },
     "manaCostFormula": {
       "base": 5,
@@ -324,8 +324,8 @@
     },
     "damageType": "fire",
     "damageFormula": {
-      "base": 0.5,
-      "perLevel": 12.5
+      "base": 0,
+      "perLevel": 10
     },
     "passiveStats": {
       "base": {
@@ -385,11 +385,11 @@
     },
     "passiveStats": {
       "base": {
-        "attack_rating": 3,
+        "attack_rating_pct": 3,
         "movement_speed": 1.5
       },
       "perRank": {
-        "attack_rating": 3,
+        "attack_rating_pct": 3,
         "movement_speed": 1.5
       }
     }
@@ -480,10 +480,10 @@
     },
     "passiveStats": {
       "base": {
-        "defense": 5
+        "defense_pct": 5
       },
       "perRank": {
-        "defense": 5
+        "defense_pct": 5
       }
     }
   },
@@ -580,12 +580,12 @@
     },
     "passiveStats": {
       "base": {
-        "life": 3,
-        "mana_replenish": 1
+        "increased_life": 3,
+        "life_replenish_pct": 1
       },
       "perRank": {
-        "life": 3,
-        "mana_replenish": 1
+        "increased_life": 3,
+        "life_replenish_pct": 1
       }
     }
   },
@@ -712,7 +712,7 @@
     "tree": "Logger",
     "position": {
       "row": 2,
-      "col": 2
+      "col": 1
     },
     "manaCostFormula": {
       "base": 5,
@@ -754,7 +754,7 @@
     "tree": "Logger",
     "position": {
       "row": 3,
-      "col": 1
+      "col": 0
     },
     "damageType": "arcane",
     "attackKind": "attack",
@@ -837,11 +837,11 @@
     "passiveStats": {
       "base": {
         "attack_damage": 6,
-        "attack_rating": 2.5
+        "attack_rating_pct": 2.5
       },
       "perRank": {
         "attack_damage": 6,
-        "attack_rating": 2.5
+        "attack_rating_pct": 2.5
       }
     }
   },


### PR DESCRIPTION
Pipe Bombs: moved from column 1 => 2
Tire Fire: moved from column 0 => 2
Oil Spill: moved from column 1 => 0
Spontaneous Combustion: base damage at rank 1 on a fresh character is 10, not 12.5
Moonshine Madness: grants % attack rating, not flat attack rating
Durable Wear: grants % defense, not flat defense
Loggers Endurance: Grants % life and % life replenish, not flat life and flat mana replenish
Revved Up: moved from column 2 => 1
Rogue Chainsaw: moved from column 1 => 0
Chainsaw Mastery: grants % attack rating, not flat attack rating

I verified all of this in-game, these values should be correct for season 9.